### PR TITLE
Add support for directory structure

### DIFF
--- a/src/main/kotlin/com/github/serverfrog/bitburnerplugin/action/BitburnerPushAction.kt
+++ b/src/main/kotlin/com/github/serverfrog/bitburnerplugin/action/BitburnerPushAction.kt
@@ -10,6 +10,6 @@ class BitburnerPushAction() : AnAction(MyBundle.message("pushActionLabel")) {
 
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)?.canonicalFile!!
-        PushToBitburner.pushToBitburner(file, e.project)
+        PushToBitburner.pushToBitburner(file, e.project!!)
     }
 }


### PR DESCRIPTION
In this commit, a relative path of a script to the IntelliJ project base path is computed, and then the script is pushed to Bitburner while keeping the relative path's directory structure.

Also, a fix of wrong regex replace (`replace("/[\\\\|/]+/g", "/")`) is included. Tested on Wndows 11.